### PR TITLE
[meta-openwrt] Fixes to build openwrt-juci-image with morty release

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,13 @@ git clone git://github.com/openembedded/meta-openembedded.git
 git clone git://github.com/openembedded/bitbake.git
 git clone git://github.com/kraj/meta-openwrt.git
 git clone git://github.com/imyller/meta-nodejs.git
+git clone git://github.com/imyller/meta-nodejs-contrib.git
 
 $ . ./oe-init-build-env
 
 $ bitbake-layers add-layer ../meta-openembedded/meta-oe
 $ bitbake-layers add-layer ../meta-nodejs
+$ bitbake-layers add-layer ../meta-nodejs-contrib
 $ bitbake-layers add-layer ../meta-openwrt
 ```
 
@@ -45,7 +47,7 @@ $ TCLIBC=musl runqemu qemuarm
 
 # Limitations
 
-Works with OE Release >= 2.1
+Works with OE Release >= 2.2
 
 Currently images are buildable/bootable for mips, arm, aarch64, ppc, x86, x86_64
 based qemu machines
@@ -68,6 +70,10 @@ branch: master
 revision: HEAD
 
 URI: git://github.com/imyller/meta-nodejs.git
+branch: master
+revision: HEAD
+
+URI: git://github.com/imyller/meta-nodejs-contrib.git
 branch: master
 revision: HEAD
 ```

--- a/classes/openwrt.bbclass
+++ b/classes/openwrt.bbclass
@@ -1,5 +1,5 @@
 OECMAKE_C_FLAGS += "-DLUA_COMPAT_5_1"
-EXTRA_OECMAKE += "-DLUAPATH=`lua5.1 -e "for k in string.gmatch(package.cpath .. \";\", \"([^;]+)/..so;\") do if k:sub(1,1) == \"/\" then print(k) break end end" | sed 's#${STAGING_DIR_NATIVE}##'`"
+EXTRA_OECMAKE += "-DLUAPATH=/usr/lib/lua/5.1"
 
 FILES_SOLIBSDEV = ""
 

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,4 +8,4 @@ BBFILE_COLLECTIONS += "openwrt-layer"
 BBFILE_PATTERN_openwrt-layer := "^${LAYERDIR}/"
 BBFILE_PRIORITY_openwrt-layer = "8"
 
-LAYERDEPENDS_openwrt-layer = "core nodejs-layer openembedded-layer"
+LAYERDEPENDS_openwrt-layer = "core nodejs openembedded-layer"

--- a/recipes-core/images/openwrt-juci-image.bb
+++ b/recipes-core/images/openwrt-juci-image.bb
@@ -1,7 +1,7 @@
 # Copyright (C) 2016 Khem Raj <raj.khem@gmail.com>
 # Released under the MIT license (see COPYING.MIT for the terms)
 
-DESCRIPTION = "JUCI based OpneWRT GUI Image"
+DESCRIPTION = "JUCI based OpenWRT GUI Image"
 HOMEPAGE = ""
 LICENSE = "MIT"
 

--- a/recipes-core/juci/jucid/0001-main.c-define-_DEFAULT_SOURCE.patch
+++ b/recipes-core/juci/jucid/0001-main.c-define-_DEFAULT_SOURCE.patch
@@ -1,0 +1,38 @@
+From f1ad96615302b81756edf1e55dc3334d6a9045a3 Mon Sep 17 00:00:00 2001
+From: "Theodore A. Roth" <theodore_roth@trimble.com>
+Date: Fri, 13 Jan 2017 09:44:54 -0700
+Subject: [PATCH] main.c: define _DEFAULT_SOURCE
+
+Fixes:
+
+| In file included from /usr/include/time.h:27:0,
+|                  from ../../git/src/main.c:23:
+| /usr/include/features.h:148:3: error: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, \
+|      use _DEFAULT_SOURCE" [-Werror=cpp]
+|  # warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"
+|    ^~~~~~~
+
+Signed-off-by: Theodore A. Roth <theodore_roth@trimble.com>
+---
+ src/main.c | 5 +----
+ 1 file changed, 1 insertion(+), 4 deletions(-)
+
+diff --git a/src/main.c b/src/main.c
+index 76a2a4b..48ca6ea 100644
+--- a/src/main.c
++++ b/src/main.c
+@@ -15,10 +15,7 @@
+ 	GNU General Public License for more details.
+ */
+ 
+-#define _XOPEN_SOURCE
+-#define _XOPEN_SOURCE_EXTENDED
+-#define _BSD_SOURCE
+-#define _POSIX_C_SOURCE 199309L
++#define _DEFAULT_SOURCE
+ 
+ #include <time.h>
+ #include <stdio.h>
+-- 
+2.7.4
+

--- a/recipes-core/juci/jucid/0002-fix-makefile-in.patch
+++ b/recipes-core/juci/jucid/0002-fix-makefile-in.patch
@@ -1,0 +1,23 @@
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 1ae0fae..ee66301 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -1,4 +1,4 @@
+ bin_PROGRAMS=revorpcd
+ revorpcd_SOURCES=base64.c juci_luaobject.c juci_session.c juci_message.c juci_id.c juci_lua.c juci.c juci_ws_server.c juci_user.c juci_uci.c sha1.c main.c
+ revorpcd_CFLAGS=-std=gnu99 -Wall -Werror
+-revorpcd_LDADD=-lblobpack -lusys -lutype -lpthread -lwebsockets -lcrypt -luci @LIBLUA_LINK@
++revorpcd_LDADD=-lblobpack -lusys -lutype -lpthread -lwebsockets -lcrypt -luci -lm -llua5.1 -lluajit-5.1 -ldl
+diff --git a/src/Makefile.in b/src/Makefile.in
+index 7731d09..a006209 100644
+--- a/src/Makefile.in
++++ b/src/Makefile.in
+@@ -250,7 +250,7 @@ top_builddir = @top_builddir@
+ top_srcdir = @top_srcdir@
+ revorpcd_SOURCES = base64.c juci_luaobject.c juci_session.c juci_message.c juci_id.c juci_lua.c juci.c juci_ws_server.c juci_user.c juci_uci.c sha1.c main.c
+ revorpcd_CFLAGS = -std=gnu99 -Wall -Werror
+-revorpcd_LDADD = -lblobpack -lusys -lutype -lpthread -lwebsockets -lcrypt -luci @LIBLUA_LINK@
++revorpcd_LDADD = -lblobpack -lusys -lutype -lpthread -lwebsockets -lcrypt -luci -lm -llua5.1 -lluajit-5.1 -ldl
+ all: all-am
+ 
+ .SUFFIXES:

--- a/recipes-core/juci/jucid_git.bb
+++ b/recipes-core/juci/jucid_git.bb
@@ -11,6 +11,8 @@ SRCREV = "b787f202a695eaba1fcc0feac1ff796fc37d4a43"
 SRC_URI = "git://github.com/mkschreder/jucid \
            file://0001-GLOB_TILDE-is-not-defined-in-posix-therefore-not-imp.patch \
            file://0001-juci_ws_server.c-ubus_srv_ws_client_new-expects-no-p.patch \
+           file://0001-main.c-define-_DEFAULT_SOURCE.patch \
+           file://0002-fix-makefile-in.patch \
            "
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Needed to make a few changes to allow building the openwrt-juci-image.bb recipe using the yocto morty release of poky.