### PR TITLE
Minor fixes to ipset and xtables-addons recipes

### DIFF
--- a/recipes-core/ipset/ipset_6.24.bb
+++ b/recipes-core/ipset/ipset_6.24.bb
@@ -7,13 +7,11 @@ LICENSE = "GPL-2.0"
 LIC_FILES_CHKSUM = "file://COPYING;md5=59530bdf33659b29e73d4adb9f9f6552"
 SECTION = "base"
 
-inherit autotools openwrt
+inherit autotools pkgconfig
 
 SRC_URI = "http://ipset.netfilter.org/${PN}-${PV}.tar.bz2"
 
 SRC_URI[md5sum] = "8831b8f01458bf2abacc222884195a62"
 SRC_URI[sha256sum] = "3071fc283f00a6472b5b352ef57f9825c9face70dda5b0d8715f8d43d0e995d0"
 
-DEPENDS += "libmnl"
-
-FILES_${PN}-dev += "${libdir}/*.so"
+DEPENDS += "libtool libmnl"

--- a/recipes-core/xtables-addons/xtables-addons_2.12.bb
+++ b/recipes-core/xtables-addons/xtables-addons_2.12.bb
@@ -6,8 +6,6 @@ RDEPENDS_${PN} += "perl"
 
 inherit autotools module-base
 
-INC_PR = "r0"
-
 SRC_URI = " \
         ${SOURCEFORGE_MIRROR}/project/${PN}/Xtables-addons/${PN}-${PV}.tar.xz \
         file://100-add-rtsp-conntrack.patch \
@@ -20,7 +18,7 @@ SRC_URI = " \
 SRC_URI[md5sum] = "aed5ce0873709ac243f1177fc81ff452"
 SRC_URI[sha256sum] = "c4865aa1c64c5ff173ff7b5d69425466c71f0f9b5eb5299c52c68bdcd46fa63b"
 
-EXTRA_OECONF = "--with-kbuild=${STAGING_KERNEL_DIR} --with-xtlibdir=/usr/lib/iptables"
+EXTRA_OECONF = "--with-kbuild=${STAGING_KERNEL_DIR} --with-xtlibdir=${libdir}/iptables"
 
 addtask make_scripts after do_patch before do_compile
 do_make_scripts[lockfiles] = "${TMPDIR}/kernel-scripts.lock"


### PR DESCRIPTION
- ipset does not need to inherit openwrt
- xtables-addons: INC_PR not needed

Signed-off-by: Aaron Brice <aaron.brice@datasoft.com>