### PR TITLE
Allow openwrt-base-image to run under qemu-x86 (includes fact upstream git repos have changed)

### DIFF
--- a/recipes-core/base-files/base-files-openwrt/00_preinit.conf
+++ b/recipes-core/base-files/base-files-openwrt/00_preinit.conf
@@ -1,0 +1,12 @@
+pi_suppress_stderr="n"
+pi_failsafe_wait_timeout=2
+pi_init_path="%PATH%"
+pi_init_env=""
+pi_init_cmd="/sbin/init"
+pi_ifname=""
+pi_ip="192.168.1.1"
+pi_netmask="255.255.255.0"
+pi_broadcast="192.168.1.255"
+pi_preinit_net_messages="n"
+pi_preinit_no_failsafe_netmsg="y"
+pi_preinit_no_failsafe=""

--- a/recipes-core/base-files/base-files-openwrt_git.bb
+++ b/recipes-core/base-files/base-files-openwrt_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "http://wiki.openwrt.org/"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=94d55d512a9ba36caa9b7df079bae19f"
 
-SRC_URI = "git://github.com/openwrt/openwrt.git;protocol=git;branch=chaos_calmer \
+SRC_URI = "git://github.com/openwrt/archive.git;protocol=git;branch=chaos_calmer \
            file://0001-use-sh-not-ash.patch \
            "
 SRCREV = "${OPENWRT_SRCREV}"

--- a/recipes-core/base-files/base-files-openwrt_git.bb
+++ b/recipes-core/base-files/base-files-openwrt_git.bb
@@ -5,6 +5,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=94d55d512a9ba36caa9b7df079bae19f"
 
 SRC_URI = "git://github.com/openwrt/archive.git;protocol=git;branch=chaos_calmer \
            file://0001-use-sh-not-ash.patch \
+           file://00_preinit.conf \
            "
 SRCREV = "${OPENWRT_SRCREV}"
 
@@ -39,6 +40,15 @@ do_install () {
     chmod 0600 ${D}/etc/shadow
     chmod 1777 ${D}/tmp
 
+    install -dm 0755 ${D}/lib/preinit
+    install -m 0644 ${WORKDIR}/00_preinit.conf ${D}/lib/preinit/00_preinit.conf
+
+    sed -i "s#%PATH%#/usr/sbin:/usr/bin:/sbin:/bin#g" \
+          ${D}/sbin/hotplug-call \
+          ${D}/etc/preinit \
+          ${D}/etc/profile \
+          ${D}/lib/preinit/00_preinit.conf
+
     mkdir -p ${D}/var/run
     mkdir -p ${D}/etc/rc.d
     for script in ${D}/etc/init.d/*
@@ -46,6 +56,8 @@ do_install () {
         grep '#!/bin/sh /etc/rc.common' $script > /dev/null || continue
         IPKG_INSTROOT=${D} /bin/bash ${D}/etc/rc.common $script enable || continue
     done
+
+    rm -f ${D}/etc/config/network
 }
 
 FILES_${PN} = "/"

--- a/recipes-core/firewall3/firewall3_git.bb
+++ b/recipes-core/firewall3/firewall3_git.bb
@@ -11,7 +11,7 @@ RDEPENDS_${PN} = "ipset xtables-addons"
 
 SRCREV = "82ccd9e34fe87d31d9909fed754950b2c75bc6ac"
 SRC_URI = "git://git.openwrt.org/project/firewall3.git \
-           git://github.com/openwrt/openwrt.git;name=openwrt;destsuffix=git/openwrt/;protocol=git;branch=chaos_calmer \
+           git://github.com/openwrt/archive.git;name=openwrt;destsuffix=git/openwrt/;protocol=git;branch=chaos_calmer \
           "
 
 inherit cmake pkgconfig openwrt

--- a/recipes-core/fstools/files/0100-Use-sysmacro-where-needed.patch
+++ b/recipes-core/fstools/files/0100-Use-sysmacro-where-needed.patch
@@ -1,0 +1,24 @@
+Index: git/libblkid-tiny/mkdev.c
+===================================================================
+--- git.orig/libblkid-tiny/mkdev.c
++++ git/libblkid-tiny/mkdev.c
+@@ -16,6 +16,7 @@
+ 
+ #include <sys/stat.h>
+ #include <sys/types.h>
++#include <sys/sysmacros.h>
+ 
+ #include <stdio.h>
+ #include <string.h>
+Index: git/libubi/libubi.c
+===================================================================
+--- git.orig/libubi/libubi.c
++++ git/libubi/libubi.c
+@@ -32,6 +32,7 @@
+ #include <sys/ioctl.h>
+ #include <sys/stat.h>
+ #include <sys/types.h>
++#include <sys/sysmacros.h>
+ #include "libubi.h"
+ #include "libubi_int.h"
+ 

--- a/recipes-core/fstools/fstools_git.bb
+++ b/recipes-core/fstools/fstools_git.bb
@@ -13,6 +13,7 @@ SECTION = "base"
 SRCREV = "96415afecef35766332067f4205ef3b2c7561d21"
 SRC_URI = "git://git.openwrt.org/project/fstools.git \
            file://0001-Define-GLOB_ONLYDIR-if-not-available.patch \
+           file://0100-Use-sysmacro-where-needed.patch \
           "
 
 inherit cmake pkgconfig

--- a/recipes-core/images/openwrt-base-image.bb
+++ b/recipes-core/images/openwrt-base-image.bb
@@ -50,7 +50,7 @@ CORE_IMAGE_EXTRA_INSTALL += "\
     ${@bb.utils.contains('COMBINED_FEATURES', 'wifi', 'hostapd', '',d)} \
 "
 
-IMAGE_FSTYPES += "cpio.gz.u-boot"
+IMAGE_FSTYPES += "ext4"
 
 SRCDIR = "${THISDIR}/${PN}"
 

--- a/recipes-core/netifd/netifd_git.bb
+++ b/recipes-core/netifd/netifd_git.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://main.c;beginline=1;endline=13;md5=572cd47ba0e377b2633
 SECTION = "base"
 DEPENDS = "json-c libubox ubus libnl uci"
 
-SRCREV_netifd = "64a655d8ffa9f0cea1bbdd35cac6b3b99b865270"
+SRCREV_pn-netifd = "64a655d8ffa9f0cea1bbdd35cac6b3b99b865270"
 SRCREV_openwrt = "${OPENWRT_SRCREV}"
 
 SRC_URI = "\

--- a/recipes-core/netifd/netifd_git.bb
+++ b/recipes-core/netifd/netifd_git.bb
@@ -13,7 +13,7 @@ SRCREV_openwrt = "${OPENWRT_SRCREV}"
 
 SRC_URI = "\
     git://git.openwrt.org/project/netifd.git;name=netifd \
-    git://github.com/openwrt/openwrt.git;name=openwrt;destsuffix=git/openwrt/;branch=chaos_calmer \
+    git://github.com/openwrt/archive.git;name=openwrt;destsuffix=git/openwrt/;branch=chaos_calmer \
     file://network.config \
     file://100-Fix-IFF_LOWER_UP-define.patch \
 "

--- a/recipes-core/procd/procd/0100-use-sysmacros-where-needed.patch
+++ b/recipes-core/procd/procd/0100-use-sysmacros-where-needed.patch
@@ -1,0 +1,36 @@
+Index: git/initd/early.c
+===================================================================
+--- git.orig/initd/early.c
++++ git/initd/early.c
+@@ -14,6 +14,7 @@
+ 
+ #include <sys/mount.h>
+ #include <sys/types.h>
++#include <sys/sysmacros.h>
+ #include <sys/stat.h>
+ 
+ #include <stdio.h>
+Index: git/plug/hotplug.c
+===================================================================
+--- git.orig/plug/hotplug.c
++++ git/plug/hotplug.c
+@@ -15,6 +15,7 @@
+ #include <sys/stat.h>
+ #include <sys/socket.h>
+ #include <sys/types.h>
++#include <sys/sysmacros.h>
+ 
+ #include <linux/types.h>
+ #include <linux/netlink.h>
+Index: git/initd/mkdev.c
+===================================================================
+--- git.orig/initd/mkdev.c
++++ git/initd/mkdev.c
+@@ -16,6 +16,7 @@
+ 
+ #include <sys/stat.h>
+ #include <sys/types.h>
++#include <sys/sysmacros.h>
+ 
+ #include <stdio.h>
+ #include <string.h>

--- a/recipes-core/procd/procd_git.bb
+++ b/recipes-core/procd/procd_git.bb
@@ -14,6 +14,7 @@ SRC_URI = "git://git.openwrt.org/project/procd.git \
            file://reload_config \
            file://hotplug.json \
            file://hotplug-preinit.json \
+           file://0100-use-sysmacros-where-needed.patch \
 "
 
 inherit cmake openwrt pkgconfig

--- a/recipes-core/xtables-addons/xtables-addons_2.12.bb
+++ b/recipes-core/xtables-addons/xtables-addons_2.12.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=751419260aa954499f7abaabaa882bbe"
 DEPENDS = "virtual/kernel iptables"
 RDEPENDS_${PN} += "perl"
 
-inherit autotools module-base
+inherit autotools module-base pkgconfig
 
 SRC_URI = " \
         ${SOURCEFORGE_MIRROR}/project/${PN}/Xtables-addons/${PN}-${PV}.tar.xz \

--- a/recipes-tweaks/dnsmasq/dnsmasq_%.bbappend
+++ b/recipes-tweaks/dnsmasq/dnsmasq_%.bbappend
@@ -2,7 +2,7 @@ inherit openwrt
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
-SRC_URI += "git://github.com/openwrt/openwrt.git;name=openwrt;destsuffix=git/openwrt/;protocol=git;branch=chaos_calmer"
+SRC_URI += "git://github.com/openwrt/archive.git;name=openwrt;destsuffix=git/openwrt/;protocol=git;branch=chaos_calmer"
 SRC_URI += "file://99-dnsmasq.rules"
 
 SRCREV_openwrt = "${OPENWRT_SRCREV}"

--- a/recipes-tweaks/iptables/iptables/600-shared-libext.patch
+++ b/recipes-tweaks/iptables/iptables/600-shared-libext.patch
@@ -1,8 +1,8 @@
-Index: iptables-1.6.0/extensions/GNUmakefile.in
+Index: iptables-1.6.1/extensions/GNUmakefile.in
 ===================================================================
---- iptables-1.6.0.orig/extensions/GNUmakefile.in
-+++ iptables-1.6.0/extensions/GNUmakefile.in
-@@ -49,11 +49,33 @@ pfb_build_mod := $(filter-out @blacklist
+--- iptables-1.6.1.orig/extensions/GNUmakefile.in
++++ iptables-1.6.1/extensions/GNUmakefile.in
+@@ -50,11 +50,33 @@ pfb_build_mod := $(filter-out @blacklist
  pfa_build_mod := $(filter-out @blacklist_modules@ @blacklist_a_modules@,${pfa_build_mod})
  pf4_build_mod := $(filter-out @blacklist_modules@ @blacklist_4_modules@,${pf4_build_mod})
  pf6_build_mod := $(filter-out @blacklist_modules@ @blacklist_6_modules@,${pf6_build_mod})
@@ -41,7 +41,7 @@ Index: iptables-1.6.0/extensions/GNUmakefile.in
  pfx_solibs    := $(patsubst %,libxt_%.so,${pfx_build_mod} ${pfx_symlinks})
  pfb_solibs    := $(patsubst %,libebt_%.so,${pfb_build_mod})
  pfa_solibs    := $(patsubst %,libarpt_%.so,${pfa_build_mod})
-@@ -64,15 +86,15 @@ pf6_solibs    := $(patsubst %,libip6t_%.
+@@ -65,15 +87,15 @@ pf6_solibs    := $(patsubst %,libip6t_%.
  #
  # Building blocks
  #
@@ -65,7 +65,7 @@ Index: iptables-1.6.0/extensions/GNUmakefile.in
  
  .SECONDARY:
  
-@@ -91,7 +113,7 @@ clean:
+@@ -92,7 +114,7 @@ clean:
  distclean: clean
  
  init%.o: init%.c
@@ -74,7 +74,7 @@ Index: iptables-1.6.0/extensions/GNUmakefile.in
  
  -include .*.d
  
-@@ -100,7 +122,7 @@ init%.o: init%.c
+@@ -101,7 +123,7 @@ init%.o: init%.c
  #	Shared libraries
  #
  lib%.so: lib%.oo
@@ -83,7 +83,7 @@ Index: iptables-1.6.0/extensions/GNUmakefile.in
  
  lib%.oo: ${srcdir}/lib%.c
  	${AM_VERBOSE_CC} ${CC} ${AM_CPPFLAGS} ${AM_DEPFLAGS} ${AM_CFLAGS} -D_INIT=lib$*_init -DPIC -fPIC ${CFLAGS} -o $@ -c $<;
-@@ -123,28 +145,28 @@ xt_connlabel_LIBADD = @libnetfilter_conn
+@@ -124,28 +146,28 @@ xt_connlabel_LIBADD = @libnetfilter_conn
  #	handling code in the Makefiles.
  #
  lib%.o: ${srcdir}/lib%.c
@@ -128,11 +128,11 @@ Index: iptables-1.6.0/extensions/GNUmakefile.in
  
  .initext.dd: FORCE
  	@echo "${initext_func}" >$@.tmp; \
-Index: iptables-1.6.0/iptables/Makefile.am
+Index: iptables-1.6.1/iptables/Makefile.am
 ===================================================================
---- iptables-1.6.0.orig/iptables/Makefile.am
-+++ iptables-1.6.0/iptables/Makefile.am
-@@ -6,7 +6,8 @@ AM_YFLAGS = -d
+--- iptables-1.6.1.orig/iptables/Makefile.am
++++ iptables-1.6.1/iptables/Makefile.am
+@@ -8,7 +8,8 @@ BUILT_SOURCES =
  
  xtables_multi_SOURCES  = xtables-multi.c iptables-xml.c
  xtables_multi_CFLAGS   = ${AM_CFLAGS}
@@ -142,21 +142,21 @@ Index: iptables-1.6.0/iptables/Makefile.am
  if ENABLE_STATIC
  xtables_multi_CFLAGS  += -DALL_INCLUSIVE
  endif
-@@ -14,22 +15,25 @@ if ENABLE_IPV4
+@@ -16,23 +17,26 @@ if ENABLE_IPV4
  xtables_multi_SOURCES += iptables-save.c iptables-restore.c \
                           iptables-standalone.c iptables.c
  xtables_multi_CFLAGS  += -DENABLE_IPV4
 -xtables_multi_LDADD   += ../libiptc/libip4tc.la ../extensions/libext4.a
-+xtables_multi_LDADD   += ${top_builddir}/libiptc/libip4tc.la
-+xtables_multi_LDFLAGS += -liptext4
++xtables_multi_LDADD   += ../libiptc/libip4tc.la
++xtables_multi_LDFLAGS += -L${top_builddir}/extensions -liptext4
  endif
  if ENABLE_IPV6
  xtables_multi_SOURCES += ip6tables-save.c ip6tables-restore.c \
                            ip6tables-standalone.c ip6tables.c
  xtables_multi_CFLAGS  += -DENABLE_IPV6
 -xtables_multi_LDADD   += ../libiptc/libip6tc.la ../extensions/libext6.a
-+xtables_multi_LDADD   += ${top_builddir}/libiptc/libip6tc.la
-+xtables_multi_LDFLAGS += -liptext6
++xtables_multi_LDADD   += ../libiptc/libip6tc.la
++xtables_multi_LDFLAGS += -L${top_builddir}/extensions -liptext6
  endif
  xtables_multi_SOURCES += xshared.c
 -xtables_multi_LDADD   += ../libxtables/libxtables.la -lm
@@ -164,6 +164,7 @@ Index: iptables-1.6.0/iptables/Makefile.am
  
  # nftables compatibility layer
  if ENABLE_NFTABLES
+ BUILT_SOURCES += xtables-config-parser.h
  xtables_compat_multi_SOURCES  = xtables-compat-multi.c iptables-xml.c
  xtables_compat_multi_CFLAGS   = ${AM_CFLAGS}
 -xtables_compat_multi_LDADD    = ../extensions/libext.a ../extensions/libext_ebt.a
@@ -172,13 +173,13 @@ Index: iptables-1.6.0/iptables/Makefile.am
  if ENABLE_STATIC
  xtables_compat_multi_CFLAGS  += -DALL_INCLUSIVE
  endif
-@@ -41,11 +45,12 @@ xtables_compat_multi_SOURCES += xtables-
- 				xtables-arp-standalone.c xtables-arp.c \
+@@ -45,11 +49,12 @@ xtables_compat_multi_SOURCES += xtables-
  				getethertype.c nft-bridge.c \
- 				xtables-eb-standalone.c xtables-eb.c
+ 				xtables-eb-standalone.c xtables-eb.c \
+ 				xtables-translate.c
 -xtables_compat_multi_LDADD   += ${libmnl_LIBS} ${libnftnl_LIBS} ${libnetfilter_conntrack_LIBS} ../extensions/libext4.a ../extensions/libext6.a ../extensions/libext_ebt.a ../extensions/libext_arpt.a
 +xtables_compat_multi_LDADD   += ${libmnl_LIBS} ${libnftnl_LIBS} ${libnetfilter_conntrack_LIBS}
-+xtables_compat_multi_LDFLAGS += -liptext6 -liptext6 -liptext_ebt -liptext_arpt
++xtables_compat_multi_LDFLAGS += -liptext4 -liptext6 -liptext_ebt -liptext_arpt
  # yacc and lex generate dirty code
  xtables_compat_multi-xtables-config-parser.o xtables_compat_multi-xtables-config-syntax.o: AM_CFLAGS += -Wno-missing-prototypes -Wno-missing-declarations -Wno-implicit-function-declaration -Wno-nested-externs -Wno-undef -Wno-redundant-decls
  xtables_compat_multi_SOURCES += xshared.c


### PR DESCRIPTION
Hi,

I've created a patch series that gets procd working on the openwrt-base-image you have - as I read you say somewhere else previously procd was hanging.  This was because of missing preinit magic, which is fixed here.

At the same time I update the git repos since without that meta-openwrt can't build as of the recent re-merge of openwrt and LEDE project.

Also various build and configure failures fixed (at least on glibc - not yet tested on musl).

Regards,

Daniel