### PR TITLE
distro: Be a better distro 'flavour' rather than distro

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,17 +26,21 @@ $ bitbake-layers add-layer ../meta-openwrt
 
 # Building
 
-Below we build for qemuarm machine as an example, add
-one of OpenWRT recipes to images e.g. in conf/local.conf add
+Below we build for qemuarm machine as an example.
+to local.conf add:
 
-CORE_IMAGE_EXTRA_INSTALL = "libubox-examples"
+INHERIT += " openwrt-distro-defaults "
 
+**NB**: juci is likely currently not working
 To include juci instead of luci add
-
 CORE_IMAGE_EXTRA_INSTALL = "juci"
+
+You can then use, for example, one of:
 
 ```shell
 $ TCLIBC=musl MACHINE=qemuarm bitbake core-image-minimal
+$ TCLIBC=musl MACHINE=qemuarm bitbake openwrt-image-base
+$ TCLIBC=musl MACHINE=qemuarm bitbake openwrt-image-full
 $ TCLIBC=musl MACHINE=qemux86 bitbake core-image-weston
 $ TCLIBC=musl MACHINE=qemux86 bitbake core-image-sato
 

--- a/classes/openwrt-distro-defaults.bbclass
+++ b/classes/openwrt-distro-defaults.bbclass
@@ -1,0 +1,4 @@
+DISTRO_FEATURES_append = " procd "
+DISTRO_FEATURES_BACKFILL_CONSIDERED_append = "sysvinit systemd"
+
+inherit openwrt-virtual-runtimes openwrt-kmods openwrt-services

--- a/classes/openwrt-kmods.bbclass
+++ b/classes/openwrt-kmods.bbclass
@@ -3,5 +3,7 @@ ROOTFS_POSTUNINSTALL_COMMAND_append = ' openwrt_flatten_modules_hook; '
 
 openwrt_flatten_modules_hook () {
     export KERNEL_VERSION="${@base_read_file('${STAGING_KERNEL_BUILDDIR}/kernel-abiversion')}"
-    cd ${IMAGE_ROOTFS} && find lib/modules/${KERNEL_VERSION} -name '*.ko' -exec sh -c 'mod="{}"; ln -sf /$mod ${IMAGE_ROOTFS}/lib/modules/${KERNEL_VERSION}/$(basename "$mod")' \;
+    if [ -d "${IMAGE_ROOTFS}/lib/modules/${KERNEL_VERSION}" ]; then
+        cd ${IMAGE_ROOTFS} && find lib/modules/${KERNEL_VERSION} -name '*.ko' -exec sh -c 'mod="{}"; ln -sf /$mod ${IMAGE_ROOTFS}/lib/modules/${KERNEL_VERSION}/$(basename "$mod")' \;
+    fi
 }

--- a/classes/openwrt-virtual-runtimes.bbclass
+++ b/classes/openwrt-virtual-runtimes.bbclass
@@ -4,7 +4,4 @@ VIRTUAL-RUNTIME_init_manager ?= "procd"
 VIRTUAL-RUNTIME_kmod_manager ?= "ubox"
 VIRTUAL-RUNTIME_syslog ?= "ubox"
 VIRTUAL-RUNTIME_base-utils ?= "busybox"
-
-DISTRO_FEATURES_BACKFILL_CONSIDERED_append = "sysvinit systemd"
-
-INHERIT += "openwrt-kmods openwrt-services"
+VIRTUAL-RUNTIME_network_manager ?= "netifd"

--- a/classes/openwrt.bbclass
+++ b/classes/openwrt.bbclass
@@ -14,12 +14,4 @@ CFLAGS += "-I${STAGING_INCDIR}/lua5.1"
 # Equivalent to tag v17.01.4
 OPENWRT_SRCREV = "444add156f2a6d92fc15005c5ade2208a978966c"
 
-VIRTUAL-RUNTIME_dev_manager ?= "procd"
-VIRTUAL-RUNTIME_login_manager ?= "busybox"
-VIRTUAL-RUNTIME_init_manager ?= "procd"
-VIRTUAL-RUNTIME_kmod_manager ?= "ubox"
-VIRTUAL-RUNTIME_syslog ?= "ubox"
-VIRTUAL-RUNTIME_base-utils ?= "busybox"
-VIRTUAL-RUNTIME_network_manager ?= "netifd"
-
-DISTRO_FEATURES_BACKFILL_CONSIDERED_append = "sysvinit systemd"
+inherit openwrt-virtual-runtimes


### PR DESCRIPTION
Drop the conf/nodistro.conf that actually ends up being a distro
and document using INHERHIT += " openwrt-distro-defaults " in local.conf OR
an actual distro's conf.  Also prevent setting DISTRO_FEATURES to include
procd from overriding DISTRO_FEATURES and thereby losing the libc locale
config used with glibc (resulting in locale build failures).

Closes https://github.com/kraj/meta-openwrt/issues/30

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>