### PR TITLE
tree-wide: Include Openwrt license when pulling from openwrt repo

### DIFF
--- a/classes/openwrt-base-files.bbclass
+++ b/classes/openwrt-base-files.bbclass
@@ -1,0 +1,11 @@
+# Use this git SRCREV for all recipes that pull files out of openwrt repository
+# Equivalent to tag v17.01.4
+OPENWRT_SRCREV = "444add156f2a6d92fc15005c5ade2208a978966c"
+
+LICENSE_append = "&GPL-2.0+"
+LIC_FILES_CHKSUM_append = " file://openwrt/LICENSE;md5=94d55d512a9ba36caa9b7df079bae19f "
+
+SRC_URI_append = "\
+	git://github.com/openwrt/openwrt.git;name=openwrt;destsuffix=git/openwrt/;protocol=git;branch=lede-17.01 \
+	"
+

--- a/classes/openwrt.bbclass
+++ b/classes/openwrt.bbclass
@@ -10,8 +10,4 @@ DEPENDS += "lua5.1-native"
 OECMAKE_C_FLAGS += "-I${STAGING_INCDIR}/lua5.1"
 CFLAGS += "-I${STAGING_INCDIR}/lua5.1"
 
-# Use this git SRCREV for all recipes that pull files out of openwrt repository
-# Equivalent to tag v17.01.4
-OPENWRT_SRCREV = "444add156f2a6d92fc15005c5ade2208a978966c"
-
 inherit openwrt-virtual-runtimes

--- a/recipes-core/firewall3/firewall3_git.bb
+++ b/recipes-core/firewall3/firewall3_git.bb
@@ -11,10 +11,9 @@ RDEPENDS_${PN} = "ipset xtables-addons"
 
 SRCREV = "a4d98aea373e04f3fdc3c492c1688ba52ce490a9"
 SRC_URI = "git://git.openwrt.org/project/firewall3.git \
-           git://github.com/openwrt/openwrt.git;name=openwrt;destsuffix=git/openwrt/;protocol=git;branch=lede-17.01 \
           "
 
-inherit cmake pkgconfig openwrt openwrt-services
+inherit cmake pkgconfig openwrt openwrt-services openwrt-base-files
 
 SRCREV_openwrt = "${OPENWRT_SRCREV}"
 

--- a/recipes-core/netifd/netifd_git.bb
+++ b/recipes-core/netifd/netifd_git.bb
@@ -9,14 +9,13 @@ SECTION = "base"
 DEPENDS = "json-c libubox ubus libnl uci"
 RDEPENDS_${PN} += " bridge-utils kernel-module-bridge base-files-scripts-openwrt "
 
-inherit cmake pkgconfig openwrt openwrt-services update-alternatives
+inherit cmake pkgconfig openwrt openwrt-services update-alternatives openwrt-base-files
 
 SRCREV_netifd = "650758b16e5185505a3fbc1307949340af70b611"
 SRCREV_openwrt = "${OPENWRT_SRCREV}"
 
 SRC_URI = "\
     git://git.openwrt.org/project/netifd.git;name=netifd \
-    git://github.com/openwrt/openwrt.git;name=openwrt;destsuffix=git/openwrt/;branch=lede-17.01 \
     file://100-Fix-IFF_LOWER_UP-define.patch \
     file://network.config \
 "

--- a/recipes-core/procd/procd_git.bb
+++ b/recipes-core/procd/procd_git.bb
@@ -12,13 +12,12 @@ RDEPENDS_${PN} += " fstools base-files-scripts-openwrt ${PN}-inittab"
 
 # NB: Is both VIRTUAL-RUNTIME-init_manager and VIRTUAL_RUNTIME-dev_manager (like systemd/systemd-udev)
 
-inherit cmake openwrt openwrt-services pkgconfig
+inherit cmake openwrt openwrt-services pkgconfig openwrt-base-files
 
 SRCREV_pn-procd = "188353099cf6fc88f145cfcb84a4db3f6523528a"
 SRCREV_openwrt = "${OPENWRT_SRCREV}"
 
 SRC_URI = "git://git.openwrt.org/project/procd.git;branch=lede-17.01 \
-	git://github.com/openwrt/openwrt.git;name=openwrt;destsuffix=git/openwrt/;branch=lede-17.01 \
 	file://00_preinit.conf \
         file://banner.failsafe \
 	file://10_sysinfo \

--- a/recipes-core/rpcd/rpcd_git.bb
+++ b/recipes-core/rpcd/rpcd_git.bb
@@ -9,14 +9,13 @@ SECTION = "base"
 DEPENDS = "json-c libubox ubus uci iwinfo"
 RDEPENDS_${PN} += "iwinfo"
 
-inherit cmake pkgconfig openwrt-services openwrt
+inherit cmake pkgconfig openwrt-services openwrt openwrt-base-files
 
 SRCREV_pn-rpcd = "cfe1e75c91bc1bac82e6caab3e652b0ebee59524"
 SRCREV_openwrt = "${OPENWRT_SRCREV}"
 
 SRC_URI = "\
 	git://git.openwrt.org/project/rpcd.git \
-	git://github.com/openwrt/openwrt.git;name=openwrt;destsuffix=git/openwrt/;branch=lede-17.01 \
 	"
 
 S = "${WORKDIR}/git"

--- a/recipes-core/uci/uci_git.bb
+++ b/recipes-core/uci/uci_git.bb
@@ -8,13 +8,12 @@ LIC_FILES_CHKSUM = "file://uci.h;beginline=1;endline=13;md5=0ee862ed12171ee619c8
 SECTION = "base"
 DEPENDS = "libubox lua5.1"
 
-inherit cmake pkgconfig openwrt
+inherit cmake pkgconfig openwrt openwrt-base-files
 
 SRCREV_pn-uci = "141b64ef84f43c954e665865b1bbf216fbf7c05f"
 SRCREV_openwrt = "${OPENWRT_SRCREV}"
 
 SRC_URI = "git://git.openwrt.org/project/uci.git;branch=lede-17.01 \
-	   git://github.com/openwrt/openwrt.git;name=openwrt;destsuffix=git/openwrt/;branch=lede-17.01 \
 	   file://0100-prevent-redefinition-of-stddef.path \
 "
 

--- a/recipes-core/uhttpd/uhttpd_git.bb
+++ b/recipes-core/uhttpd/uhttpd_git.bb
@@ -9,12 +9,11 @@ SECTION = "base"
 DEPENDS = "libubox ubus json-c ustream-ssl"
 RDEPENDS_${PN} += "openssl base-files-scripts-openwrt"
 
-inherit cmake pkgconfig openwrt-services openwrt
+inherit cmake pkgconfig openwrt-services openwrt openwrt-base-files
 
 SRCREV = "a235636a2687fafb9c474e4b134a59ff66425c92"
 SRCREV_openwrt = "${OPENWRT_SRCREV}"
 SRC_URI = "git://git.openwrt.org/project/uhttpd.git \
-	git://github.com/openwrt/openwrt.git;name=openwrt;destsuffix=git/openwrt/;branch=lede-17.01 \
 	"
 
 S = "${WORKDIR}/git"

--- a/recipes-extended/mountd/mountd_git.bb
+++ b/recipes-extended/mountd/mountd_git.bb
@@ -9,7 +9,7 @@ SECTION = "base"
 DEPENDS = "libubox uci virtual/kernel"
 RRDEPENDS_${PN} = "kernel-module-fs-auto_fs4"
 
-inherit openwrt openwrt-services
+inherit openwrt openwrt-services openwrt-base-files
 
 SRCREV_mountd = "7826ca5d6aca691dcb6f98ab203a090d42e79337"
 SRCREV_openwrt = "${OPENWRT_SRCREV}"
@@ -17,7 +17,6 @@ SRCREV_openwrt = "${OPENWRT_SRCREV}"
 inherit cmake pkgconfig
 
 SRC_URI = "git://git.openwrt.org/project/mountd.git;name=mountd \
-	   git://github.com/openwrt/openwrt.git;name=openwrt;destsuffix=git/openwrt/;branch=lede-17.01 \
 	   file://0100-prevent-stddef-redefinition.patch \
 	   file://0200-prevent-musl-endian-h-parenthese-warning.patch \
 "

--- a/recipes-tweaks/base-files/base-files-openwrt/0001-use-sh-not-ash.patch
+++ b/recipes-tweaks/base-files/base-files-openwrt/0001-use-sh-not-ash.patch
@@ -1,7 +1,7 @@
-diff --git a/package/base-files/files/lib/functions/uci-defaults.sh b/package/base-files/files/lib/functions/uci-defaults.sh
+diff --git a/git/openwrt/package/base-files/files/lib/functions/uci-defaults.sh b/git/openwrt/package/base-files/files/lib/functions/uci-defaults.sh
 index 7222ff8..03084f5 100755
---- a/package/base-files/files/lib/functions/uci-defaults.sh
-+++ b/package/base-files/files/lib/functions/uci-defaults.sh
+--- a/git/openwrt/package/base-files/files/lib/functions/uci-defaults.sh
++++ b/git/openwrt/package/base-files/files/lib/functions/uci-defaults.sh
 @@ -1,4 +1,4 @@
 -#!/bin/ash
 +#!/bin/sh

--- a/recipes-tweaks/base-files/base-files-scripts.bb
+++ b/recipes-tweaks/base-files/base-files-scripts.bb
@@ -1,4 +1,4 @@
-inherit openwrt
+inherit openwrt openwrt-base-files
 
 DESCRIPTION = "Subpackages from base-files from OpenWrt core"
 HOMEPAGE = "http://wiki.openwrt.org/"

--- a/recipes-tweaks/base-files/base-files_3.%.bbappend
+++ b/recipes-tweaks/base-files/base-files_3.%.bbappend
@@ -1,18 +1,20 @@
-inherit openwrt
+inherit openwrt openwrt-base-files
 
 DESCRIPTION = "Base files from openembedded and openwrt project"
 HOMEPAGE = "http://wiki.openwrt.org/"
-LICENSE = "GPLv2"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=94d55d512a9ba36caa9b7df079bae19f"
+
+LIC_FILES_CHKSUM_remove = " file://openwrt/LICENSE;md5=94d55d512a9ba36caa9b7df079bae19f "
+LIC_FILES_CHKSUM_append = " file://git/openwrt/LICENSE;md5=94d55d512a9ba36caa9b7df079bae19f "
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}-openwrt:"
 
-SRC_URI += "git://github.com/openwrt/openwrt.git;protocol=git;branch=lede-17.01 \
+SRC_URI += "\
         file://0001-use-sh-not-ash.patch \
 	"
 SRCREV = "${OPENWRT_SRCREV}"
 
-S = "${WORKDIR}/git"
+S = "${WORKDIR}"
+SG = "${WORKDIR}/git/openwrt"
 STMP = "${WORKDIR}/stmp"
 
 do_configure[noexec] = "1"
@@ -27,7 +29,7 @@ do_install_append () {
         # belong in other recipes, or are not applicable
         rm -rf ${STMP}
         mkdir -p ${STMP}
-        cp -dR --preserve=mode,links ${S}/package/base-files/files/* ${STMP}/
+        cp -dR --preserve=mode,links ${SG}/package/base-files/files/* ${STMP}/
 
         # procd - earlyinit
         rm -f ${STMP}/etc/inittab

--- a/recipes-tweaks/dnsmasq/dnsmasq_%.bbappend
+++ b/recipes-tweaks/dnsmasq/dnsmasq_%.bbappend
@@ -1,9 +1,12 @@
-inherit openwrt openwrt-services useradd
+inherit openwrt openwrt-services useradd openwrt-base-files
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
-SRC_URI += "git://github.com/openwrt/openwrt.git;name=openwrt;destsuffix=git/openwrt/;protocol=git;branch=lede-17.01"
 SRC_URI += "file://99-dnsmasq.rules"
+
+
+LIC_FILES_CHKSUM_remove = " file://openwrt/LICENSE;md5=94d55d512a9ba36caa9b7df079bae19f "
+LIC_FILES_CHKSUM_append = " file://../git/openwrt/LICENSE;md5=94d55d512a9ba36caa9b7df079bae19f "
 
 SRCREV_openwrt = "${OPENWRT_SRCREV}"
 

--- a/recipes-tweaks/hostapd/hostapd_%.bbappend
+++ b/recipes-tweaks/hostapd/hostapd_%.bbappend
@@ -1,9 +1,8 @@
-inherit openwrt
+inherit openwrt openwrt-base-files
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 SRC_URI += "file://300-noscan.patch"
-SRC_URI += "git://github.com/openwrt/openwrt.git;name=openwrt;destsuffix=git/openwrt/;protocol=git;branch=lede-17.04"
 
 SRCREV_openwrt = "${OPENWRT_SRCREV}"
 


### PR DESCRIPTION
Recipes pulling scripts and configs from openwrt.git were not
indicating the GPL-2.0+ license on that repo.  Therefore add
the LICENSE file from openwrt.git and update LICENSE with an
'&GPL-2.0+'.  Since this is primarily initscripts and such,
while most of the actual software (like procd, ubus) etc is
under an MIT, BSD, or Apache license, it may be desirable to
replace the scripts with MIT, BSD, or Apache scripts.

Closes https://github.com/kraj/meta-openwrt/issues/43

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>