### PR TITLE
Add v6 odhcpd and dhcp6c which are now part of openwrt base upstream

### DIFF
--- a/recipes-core/odhcp6c/odhcp6c_git.bb
+++ b/recipes-core/odhcp6c/odhcp6c_git.bb
@@ -1,0 +1,34 @@
+# Copyright (C) 2018 Daniel Dickinson <cshored@thecshore.com>
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+SUMMARY = "OpenWrt DHCPv6 client"
+HOMEPAGE = "http://git.openwrt.org/?p=project/odhcp63.git;a=summary"
+LICENSE = "GPL-2.0"
+LIC_FILES_CHKSUM = "file://src/odhcp6c.c;beginline=1;endline=13;md5=ec68aaa1b08cfe27d1dc420d2edc0fc7"
+SECTION = "base"
+DEPENDS = "libubox"
+
+SRCREV_odhcp6c = "c13b6a05dbd9174356cc4b7fd1edf39445efd982"
+
+SRC_URI = "\
+          git://git.openwrt.org/project/odhcp6c.git;name=odhcp6c \
+          "
+
+S = "${WORKDIR}/git"
+OF = "${S}/openwrt/package/network/ipv6/odhcp6c/files"
+
+inherit cmake pkgconfig openwrt openwrt-services openwrt-base-files
+
+SRCREV_openwrt = "${OPENWRT_SRCREV}"
+
+do_install_append() {
+    install -Dm 0755 ${OF}/dhcpv6.sh ${D}${base_libdir}/netifd/proto/dhcpv6.sh
+    install -Dm 0755 ${OF}/dhcpv6.script ${D}${base_libdir}/netifd/dhcpv6.script
+}
+
+FILES_${PN} += "\
+               ${base_libdir}/netifd/proto/dhcpv6.sh \
+               ${base_libdir}/netifd/dhcpv6.script \
+               "
+
+RRECOMMENDS_${PN} += "netifd"

--- a/recipes-core/odhcpd/odhcpd/0100-OE-build-fails-due-to-libnl-tiny-dependency-in-CMakeLists.patch
+++ b/recipes-core/odhcpd/odhcpd/0100-OE-build-fails-due-to-libnl-tiny-dependency-in-CMakeLists.patch
@@ -1,0 +1,26 @@
+Fix "OE fails to build because of CMake dependency on libnl-tiny"
+
+Upstream has a stripped down version of libnl-3 called libnl-tiny
+that OpenEmbedded doesn't have, therefore we need to modify the
+CMakeLists.txt to properly handle the libnl-3 library instead
+f libnl-tiny.
+
+Signed-of-by: "Daniel F. Dickinson <cshored@thecshore.com>"
+Index: git/CMakeLists.txt
+===================================================================
+--- git.orig/CMakeLists.txt
++++ git/CMakeLists.txt
+@@ -8,10 +8,10 @@ set(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS ""
+ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -std=c99")
+ 
+ FIND_PATH(ubox_include_dir libubox/uloop.h)
+-FIND_PATH(libnl-tiny_include_dir netlink-generic.h PATH_SUFFIXES libnl-tiny)
+-INCLUDE_DIRECTORIES(${ubox_include_dir} ${libnl-tiny_include_dir})
++FIND_PATH(libnl3_include_dir netlink/msg.h PATH_SUFFIXES libnl3)
++INCLUDE_DIRECTORIES(${ubox_include_dir} ${libnl3_include_dir})
+ 
+-FIND_LIBRARY(libnl NAMES nl-tiny)
++FIND_LIBRARY(libnl NAMES nl-3)
+ 
+ add_definitions(-D_GNU_SOURCE -Wall -Werror -Wextra)
+ 

--- a/recipes-core/odhcpd/odhcpd_git.bb
+++ b/recipes-core/odhcpd/odhcpd_git.bb
@@ -1,0 +1,41 @@
+# Copyright (C) 2018 Daniel Dickinson <cshored@thecshore.com>
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+SUMMARY = "OpenWrt DHCP/DHCPv6(-PD)/RA Server & Relay"
+HOMEPAGE = "http://git.openwrt.org/?p=project/odhcpd.git;a=summary"
+LICENSE = "GPL-2.0"
+LIC_FILES_CHKSUM = "file://src/odhcpd.c;beginline=1;endline=13;md5=b5b1da01ca7e1cdd0308c552dc0a1384"
+SECTION = "base"
+DEPENDS = "libubox ubus libnl uci"
+
+FILESEXTRAPATHS_prepend = "${THIDIR}/${PN}:"
+
+SRC_URI = "\
+    git://git.openwrt.org/project/odhcpd.git;name=odhcpd \
+    file://0100-OE-build-fails-due-to-libnl-tiny-dependency-in-CMakeLists.patch \
+"
+
+SRCREV_odhcpd = "750e457e3000187b85906814a2529ede24775325"
+
+S = "${WORKDIR}/git"
+OF = "${S}/openwrt/package/network/services/odhcpd/files"
+
+inherit cmake pkgconfig openwrt openwrt-services openwrt-base-files
+
+SRCREV_openwrt = "${OPENWRT_SRCREV}"
+
+EXTRA_OECMAKE_append = " -DUBUS=1"
+
+do_install_append() {
+    install -Dm 0644 ${OF}/odhcpd.defaults ${D}${sysconfdir}/uci-defaults/odhcpd
+    install -Dm 0755 ${OF}/odhcpd.init ${D}${sysconfdir}/init.d/odhcpd
+    install -Dm 0755 ${OF}/odhcpd-update ${D}${sbindir}/odhcpd-update
+}
+
+FILES_${PN} += "\
+               ${sysconfdir}/uci-defaults/odhcpd.defaults \
+               ${sysconfdir}/init.d/odhcpd \
+               ${sbindir}/odhcpd-update \
+               "
+
+RDEPENDS_${PN} += "base-files-scripts-openwrt"

--- a/recipes-core/packagegroups/packagegroup-openwrt-minimal.bb
+++ b/recipes-core/packagegroups/packagegroup-openwrt-minimal.bb
@@ -35,4 +35,5 @@ RDEPENDS_${PN}-network = "\
     ustream-ssl \
     ${@bb.utils.contains('COMBINED_FEATURES', 'wifi', 'iw', '',d)} \
     ${@bb.utils.contains('COMBINED_FEATURES', 'wifi', 'hostapd', '',d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'ipv6', 'odhcp6c', '', d)} \
     "

--- a/recipes-extended/packagegroups/packagegroup-openwrt-base.bb
+++ b/recipes-extended/packagegroups/packagegroup-openwrt-base.bb
@@ -28,6 +28,7 @@ RDEPENDS_${PN}-network = "\
     dnsmasq \
     \
     ${@bb.utils.contains('COMBINED_FEATURES', 'wifi', 'iwinfo', '',d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'ipv6', 'odhcpd', '', d)} \
     umdnsd \
     "
 


### PR DESCRIPTION
odhcpd is the default DHCPv6(-PD)/RA server and relay in openwrt-core, so add it to openwrt-minimal.  Also make sure it works by having dnsmasq be sure to ship /etc/config/dhcp (which odhcpd also relies on; seems a bit excessive to make this single file a common package though).