### PR TITLE
Luci: Fix "realtime graphs displaying no data"

### DIFF
--- a/recipes-extended/luci/luci/cmake.patch
+++ b/recipes-extended/luci/luci/cmake.patch
@@ -134,7 +134,7 @@ Index: git/modules/luci-mod-admin-full/CMakeLists.txt
 +)
 +
 +INSTALL(TARGETS luci-bwc
-+	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
++	RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
 +)
 +
 +INSTALL(DIRECTORY htdocs/

--- a/recipes-extended/luci/luci_git.bb
+++ b/recipes-extended/luci/luci_git.bb
@@ -18,10 +18,10 @@ inherit cmake openwrt pkgconfig
 
 prefix=""
 includedir="/usr/include"
+bindir="usr/bin"
 
-OECMAKE_C_FLAGS += "-I${STAGING_INCDIR}/libnl3"
+OECMAKE_C_FLAGS += "-I${STAGING_INCDIR}/libnl3 -DDESTDIR=${D}"
 
-FILES_${PN} += "/www /usr/lib /usr/share/acl.d"
+FILES_${PN} += "/www /usr/lib /usr/share/acl.d /${bindir}"
 
 S = "${WORKDIR}/git/"
-


### PR DESCRIPTION
The first patch fixes the hard-coded path in uhttpd so that it matches the default path for profile and initscripts so that luci finds the same binaries when there are two binaries of the same name in two different locations.

The second patch fixes the CMake created for building luci and the recipe for luci so that luci-bwc is built and installed in the correct location so that realtime graphs display activity.