### PR TITLE
iwinfo doesn't like parallel builds, so don't

### DIFF
--- a/recipes-core/iwinfo/iwinfo_git.bb
+++ b/recipes-core/iwinfo/iwinfo_git.bb
@@ -8,11 +8,10 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=751419260aa954499f7abaabaa882bbe"
 SECTION = "base"
 DEPENDS += "uci lua5.1"
 
+SRCREV = "fd9e17be0c43bd6b8df5371f0b353747bc563874"
+
 inherit openwrt
 
-CFLAGS += "-fPIC"
-
-SRCREV = "fd9e17be0c43bd6b8df5371f0b353747bc563874"
 SRC_URI = "git://git.openwrt.org/project/iwinfo.git \
            file://0001-fix-typo-in-spcifying-typename-luaL_Reg.patch \
            file://0001-fix-order-of-linker-cmdline-to-help-linking-when-usi.patch \
@@ -20,6 +19,8 @@ SRC_URI = "git://git.openwrt.org/project/iwinfo.git \
           "
 
 S = "${WORKDIR}/git"
+
+CFLAGS += "-fPIC"
 
 do_install() {
 	install -D -m 0755 ${B}/libiwinfo.so ${D}${libdir}/libiwinfo.so

--- a/recipes-core/iwinfo/iwinfo_git.bb
+++ b/recipes-core/iwinfo/iwinfo_git.bb
@@ -22,6 +22,9 @@ S = "${WORKDIR}/git"
 
 CFLAGS += "-fPIC"
 
+# iwinfo breaks with parallel make
+PARALLEL_MAKE = ""
+
 do_install() {
 	install -D -m 0755 ${B}/libiwinfo.so ${D}${libdir}/libiwinfo.so
         install -D -m 0755 ${B}/iwinfo.so ${D}${libdir}/lua/5.1/iwinfo.so


### PR DESCRIPTION
splitting this out from the styleguide series.   Prevents intermittent build failures on iwinfo with BitBake 1.34 due to parallel make failing.