### PR TITLE
busybox: Fix no-ifupdown for busybox 1.27

### DIFF
--- a/recipes-tweaks/busybox/busybox/fragment-noifupdown.cfg
+++ b/recipes-tweaks/busybox/busybox/fragment-noifupdown.cfg
@@ -1,1 +1,2 @@
-# CONFIG_IFUPDOWN is not set
+# CONFIG_IFUP is not set
+# CONFIG_IFDOWN is not set


### PR DESCRIPTION
Newest busybox splits ifupdown into ifup and ifdown configuration
options.  This means we need to update the fragment that turns off
ifup/ifdown so that it doesn't interfere with netifd

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>