### PR TITLE
Initial support for more openwrt, more oe, or neutral flavours of meta-openwrt

### DIFF
--- a/recipes-tweaks/base-files/base-files-scripts.bb
+++ b/recipes-tweaks/base-files/base-files-scripts.bb
@@ -11,7 +11,8 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=94d55d512a9ba36caa9b7df079bae19f"
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}-scripts:"
 
 SRC_URI += "git://github.com/openwrt/openwrt.git;protocol=git;branch=lede-17.01 \
-	"
+           "
+
 SRCREV = "${OPENWRT_SRCREV}"
 
 S = "${WORKDIR}/git"
@@ -21,14 +22,14 @@ do_configure[noexec] = "1"
 do_compile[noexec] = "1"
 
 PACKAGES = "\
-	${PN}-openwrt \
-	${PN}-sysupgrade \
-	"
+           ${PN}-openwrt \
+           ${PN}-sysupgrade \
+           "
 
 do_install_append () {
     mkdir -p ${D}${sysconfdir}/config
 
-    install -Dm 0644 ${SC}/lib/functions.sh ${D}/lib/functions.sh 
+    install -Dm 0644 ${SC}/lib/functions.sh ${D}/lib/functions.sh
     install -Dm 0644 ${SC}/lib/functions/uci-defaults.sh ${D}/lib/functions/uci-defaults.sh
     install -Dm 0644 ${SC}/lib/functions/system.sh ${D}/lib/functions/system.sh
     install -Dm 0755 ${SC}/bin/ipcalc.sh ${D}/bin/ipcalc.sh
@@ -41,26 +42,26 @@ do_install_append () {
 }
 
 FILES_${PN}-openwrt = "\
-	/lib/functions.sh \
-	/lib/functions/uci-defaults.sh \
-	/lib/functions/system.sh \
-	/bin/ipcalc.sh \
-        ${sysconfdir}/config \
-	"
+                      /lib/functions.sh \
+                      /lib/functions/uci-defaults.sh \
+                      /lib/functions/system.sh \
+                      /bin/ipcalc.sh \
+                      ${sysconfdir}/config \
+                      "
 
 FILES_${PN}-sysupgrade = "\
-	/etc/sysupgrade.conf \
-	/sbin/sysupgrade \
-	/lib/upgrade/* \
-	/sbin/firstboot \
-	"
+                         /etc/sysupgrade.conf \
+                         /sbin/sysupgrade \
+                         /lib/upgrade/* \
+                         /sbin/firstboot \
+                         "
 
 CONFFILES_${PN}-openwrt += "\
-    ${sysconfdir}/config \
-"
+                           ${sysconfdir}/config \
+                           "
 
 CONFFILES_${PN}-sysupgrade += "\
-    ${sysconfdir]/sysupgrade.conf \
-"
+                              ${sysconfdir]/sysupgrade.conf \
+                              "
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/recipes-tweaks/base-files/base-files-scripts.bb
+++ b/recipes-tweaks/base-files/base-files-scripts.bb
@@ -1,8 +1,11 @@
+# Copyright (C) 2018 Daniel Dickinson <cshored@thecshore.com>
+# Released under the MIT license.  See COPYING.MIT for terms
+
 inherit openwrt openwrt-base-files
 
 DESCRIPTION = "Subpackages from base-files from OpenWrt core"
 HOMEPAGE = "http://wiki.openwrt.org/"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=94d55d512a9ba36caa9b7df079bae19f"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}-scripts:"

--- a/recipes-tweaks/base-files/base-files_3.%.bbappend
+++ b/recipes-tweaks/base-files/base-files_3.%.bbappend
@@ -20,7 +20,7 @@ S = "${WORKDIR}"
 SG = "${WORKDIR}/git/openwrt"
 STMP = "${WORKDIR}/stmp"
 
-inherit openwrt openwrt-base-files
+inherit openwrt-virtual-runtimes openwrt-base-files
 
 do_configure[noexec] = "1"
 do_compile[noexec] = "1"

--- a/recipes-tweaks/busybox/busybox_1.27%.bbappend
+++ b/recipes-tweaks/busybox/busybox_1.27%.bbappend
@@ -5,12 +5,16 @@
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
+PACKAGECONFIG ??= ""
+PACKAGECONFIG[preferoe] = ""
+
 SRC_URI += "\
     file://fragment-lock.cfg \
-    file://fragment-noifupdown.cfg \
+    ${@bb.utils.contains('PACKAGECONFIG', 'preferoe', '', 'file://fragment-noifupdown.cfg', d)} \
     file://220-add_lock_util.patch \
     file://z300-fix_off_t_misdetection_triggered_without_LFS.patch \
 "
+
 do_install_append () {
     rm -f ${D}/usr/share/udhcpc/default.script
 }


### PR DESCRIPTION
This is some initial PACKAGECONFIG work to allow to choose a more openwrt-like image, a neutral (the default) which has some openwrt-specific things, but is not as close to upstream openwrt, and more oe-based (more for picking out specific packages from meta-openwrt without requiring too much from openwrt just to do that).