### PR TITLE
rm /lib drops all the needed files for 32bit targets

### DIFF
--- a/recipes-core/netifd/netifd_git.bb
+++ b/recipes-core/netifd/netifd_git.bb
@@ -56,10 +56,6 @@ do_install_append() {
     install -dm 0755 ${D}/etc/modules.d ${D}/etc/modules-load.d
     echo "bridge" >${D}/etc/modules.d/30-bridge
     echo "bridge" >${D}/etc/modules-load.d/bridge.conf
-
-    # Remove duplicate files under /lib/
-    rm -rf ${D}/lib/
-
 }
 
 ALTERNATIVE_${PN} = "ifup ifdown default.script"


### PR DESCRIPTION
Removing with "rm -rf ${D}/lib" drops all the necessary files
for 32 bit target. This is applicable only if the target is 64bit.

Copying with care using ${base_libdir} is fixes the problem.
Removing is not necessary.

Signed-off-by: Parthiban Nallathambi <pn@denx.de>