### PR TITLE
Use /run instead of /tmp

### DIFF
--- a/recipes-core/netifd/netifd/0001-resolv.conf.auto-Use-run-instead-of-tmp.patch
+++ b/recipes-core/netifd/netifd/0001-resolv.conf.auto-Use-run-instead-of-tmp.patch
@@ -1,0 +1,46 @@
+From 587e3af4084e477c244750028937cbfa54bf6c71 Mon Sep 17 00:00:00 2001
+From: Parthiban Nallathambi <pn@denx.de>
+Date: Fri, 8 Jun 2018 18:41:43 +0200
+Subject: [PATCH] [resolv.conf.auto]: Use /run instead of /tmp
+
+Using netifd as network manager along with systemd provokes the bad usage
+of path, in this case /tmp/. All the runtime configuration needs to be
+sotored as part of /run
+
+Problem:
+========
+assuming: ln -fs /tmp/resolv.conf.auto /etc/resolv.conf
+
+If any application tend to use Filesystem namespace to have separate /tmp and
+try to use DNS resolution from netifd, it will not be able to resolve the path/symlink.
+
+Usage of PrivateTmp=yes:
+------------------------
+For example, systemd-timesyncd.service in systemd uses the option "PrivateTmp=yes"
+in the service file to have separate /tmp filesystem namespace and uses glibc
+getaddrinfo for name resolution, which in turm follows the symlink to /tmp which
+doesn't exit in new namespace
+
+So moving the runtime configuration to /run here
+
+Signed-off-by: Parthiban Nallathambi <pn@denx.de>
+---
+ netifd.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/netifd.h b/netifd.h
+index 0cd4155..65d9451 100644
+--- a/netifd.h
++++ b/netifd.h
+@@ -38,7 +38,7 @@
+ #define DEFAULT_MAIN_PATH	"/lib/netifd"
+ #define DEFAULT_CONFIG_PATH	NULL /* use the default set in libuci */
+ #define DEFAULT_HOTPLUG_PATH	"/sbin/hotplug-call"
+-#define DEFAULT_RESOLV_CONF	"/tmp/resolv.conf.auto"
++#define DEFAULT_RESOLV_CONF	"/run/resolv.conf.auto"
+ #define DEFAULT_ETC_RESOLV	"/etc/resolv.conf"
+ #endif
+ 
+-- 
+2.14.4
+

--- a/recipes-core/netifd/netifd_git.bb
+++ b/recipes-core/netifd/netifd_git.bb
@@ -15,6 +15,7 @@ SRC_URI = "\
           file://network.config \
           file://200-buffer-overflow-fix.patch \
           file://300-replace-is_error-helper-with-NULL-check.patch \
+	  file://0001-resolv.conf.auto-Use-run-instead-of-tmp.patch \
           "
 
 SRCREV_netifd = "650758b16e5185505a3fbc1307949340af70b611"


### PR DESCRIPTION
Using netifd as network manager along with systemd provokes the bad usage
of path, in this case /tmp/. All the runtime configuration needs to be
sotored as part of /run

Problem:
========
assuming: ln -fs /tmp/resolv.conf.auto /etc/resolv.conf

If any application tend to use Filesystem namespace to have separate /tmp and
try to use DNS resolution from netifd, it will not be able to resolve the path/symlink.

Usage of PrivateTmp=yes:
------------------------
For example, systemd-timesyncd.service in systemd uses the option "PrivateTmp=yes"
in the service file to have separate /tmp filesystem namespace and uses glibc
getaddrinfo for name resolution, which in turm follows the symlink to /tmp which
doesn't exit in new namespace

So moving the runtime configuration to /run here

Signed-off-by: Parthiban Nallathambi <pn@denx.de>