### PR TITLE
luci: install library to /usr/lib

### DIFF
--- a/recipes-extended/luci/luci_git.bb
+++ b/recipes-extended/luci/luci_git.bb
@@ -18,10 +18,11 @@ inherit cmake openwrt pkgconfig
 
 prefix=""
 includedir="/usr/include"
-bindir="usr/bin"
+bindir="/usr/bin"
+libdir="/usr/lib"
 
 OECMAKE_C_FLAGS += "-I${STAGING_INCDIR}/libnl3 -DDESTDIR=${D}"
 
-FILES_${PN} += "/www /usr/lib /usr/share/acl.d /${bindir}"
+FILES_${PN} += "/www /lib /usr/share/acl.d ${bindir} ${libdir}"
 
 S = "${WORKDIR}/git/"


### PR DESCRIPTION
The libraries is installed to /lib make luci doesn't work correctly.