### PR TITLE
iptables: call split packages correctly

### DIFF
--- a/recipes-tweaks/iptables/iptables_1.6%.bbappend
+++ b/recipes-tweaks/iptables/iptables_1.6%.bbappend
@@ -13,7 +13,7 @@ SRC_URI += "file://600-shared-libext.patch"
 LDFLAGS += "-fuse-ld=bfd"
 
 python populate_packages_prepend() {
-    modules = do_split_packages(d, '${libdir}/${XTLIBDIR}', 'lib(.*)\.so$', '${PN}-module-%s', '${PN} module %s', extra_depends='')
+    modules = do_split_packages(d, '${XTLIBDIR}', 'lib(.*)\.so$', '${PN}-module-%s', '${PN} module %s', extra_depends='', prepend=True)
     if modules:
         metapkg = d.getVar('PN') + '-modules'
         d.appendVar('RDEPENDS_' + metapkg, ' ' + ' '.join(modules))
@@ -23,8 +23,6 @@ do_install_append() {
 	install -d ${D}${libdir}
 	install -m 0644 ${B}/extensions/libiptext*.so ${D}${libdir}
 }
-
-RDEPENDS_${PN}_remove = "${PN}-module-xt-standard"
 
 FILES_${PN} += "${libdir}/*.so"
 FILES_SOLIBSDEV = ""


### PR DESCRIPTION
Fix the arguments of the do_split_packages function, to look
in the correct place for files, and also use prepend=True
so the different module packages look for matching files before
$PN, provide a better solution avoiding RDEPENDS_remove.

Signed-off-by: Alejandro Hernandez <aehs29@gmail.com>