### PR TITLE
Can't compile rpcd. Missing crypt library.

### DIFF
--- a/recipes-core/rpcd/rpcd_git.bb
+++ b/recipes-core/rpcd/rpcd_git.bb
@@ -6,7 +6,7 @@ HOMEPAGE = "http://git.openwrt.org/?p=project/rpcd.git;a=summary"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://main.c;beginline=1;endline=18;md5=da5faf55ed0618f0dde1c88e76a0fc74"
 SECTION = "base"
-DEPENDS = "json-c libubox ubus uci iwinfo"
+DEPENDS = "json-c libubox ubus uci iwinfo virtual/crypt"
 
 SRC_URI = "\
 	git://git.openwrt.org/project/rpcd.git;name=rpcd; \


### PR DESCRIPTION
Relevant trimmed build error:
```
in function `rpc_login_test_password':
/usr/src/debug/rpcd/git-r0/git/session.c:823: undefined reference to `crypt'
```