### PR TITLE
classes/kmods: assure kernel-abiversion exists

### DIFF
--- a/classes/openwrt-kmods.bbclass
+++ b/classes/openwrt-kmods.bbclass
@@ -3,10 +3,13 @@
 # It is released under the MIT license.  See COPYING.MIT
 # for the terms.
 
+do_rootfs[depends] += " virtual/kernel:do_shared_workdir"
+
 ROOTFS_POSTUNINSTALL_COMMAND_append = ' openwrt_flatten_modules_hook; '
 
 openwrt_flatten_modules_hook () {
     export KERNEL_VERSION="${@oe.utils.read_file('${STAGING_KERNEL_BUILDDIR}/kernel-abiversion')}"
+    [ -n "${KERNEL_VERSION}" ]
     if [ -d "${IMAGE_ROOTFS}/lib/modules/${KERNEL_VERSION}" ]; then
         cd ${IMAGE_ROOTFS} && find lib/modules/${KERNEL_VERSION} -name '*.ko' -exec sh -c 'mod="{}"; ln -sf /$mod ${IMAGE_ROOTFS}/lib/modules/${KERNEL_VERSION}/$(basename "$mod")' \;
     fi


### PR DESCRIPTION
If the deploy and tmp directories were zapped but the sstate-cache
retained, it could happen that openwrt_flatten_modules_hook was run
without ${STAGING_KERNEL_BUILDDIR} ever being populated.  Add an
explicit dependency to fix that.  Also add a check that something
was actually read from the kernel-abiversion file.