### PR TITLE
Fix and replace libxcrypt (branch master with toolchain MUSL)

### DIFF
--- a/recipes-extended/luci/luci_git.bb
+++ b/recipes-extended/luci/luci_git.bb
@@ -6,7 +6,7 @@ HOMEPAGE = "https://github.com/openwrt/luci"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=2b42edef8fa55315f34f2370b4715ca9"
 SECTION = "base"
-DEPENDS = "json-c libubox libnl lua5.1 iwinfo openssl libxcrypt"
+DEPENDS = "json-c libubox libnl lua5.1 iwinfo openssl virtual/crypt"
 RDEPENDS_${PN} = "lua5.1"
 
 SRCREV = "07d9006d239b29c9377fccb91b45eb2d0e447919"

--- a/recipes-networking/uhttpd/uhttpd_git.bb
+++ b/recipes-networking/uhttpd/uhttpd_git.bb
@@ -6,7 +6,7 @@ HOMEPAGE = "http://git.openwrt.org/?p=project/uhttpd.git;a=summary"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://main.c;beginline=1;endline=18;md5=ba30601dd30339f7ff3d0ad681d45679"
 SECTION = "base"
-DEPENDS = "libubox ubus json-c ustream-ssl libxcrypt"
+DEPENDS = "libubox ubus json-c ustream-ssl virtual/crypt"
 
 SRC_URI = "\
           git://git.openwrt.org/project/uhttpd.git \


### PR DESCRIPTION
**ERROR**
`
Nothing PROVIDES 'libxcrypt' (but /media/cbueno/DATA/yocto/b2open-training/poky-gatesgarth/meta-openwrt/recipes-networking/uhttpd/uhttpd_git.bb, /media/cbueno/DATA/yocto/b2open-training/poky-gatesgarth/meta-openwrt/recipes-extended/luci/luci_git.bb DEPENDS on or otherwise requires it)
libxcrypt was skipped: PREFERRED_PROVIDER_virtual/crypt set to musl, not libxcrypt
`

Change libxcrypt by variable virtual/crypt.

Branch tested: **gatesgarth**
Tested with MACHINES: **raspberrypi4**