### PR TITLE
Update SRCREV in umdnsd to correct compilation error 

### DIFF
--- a/recipes-extended/luci/luci_git.bb
+++ b/recipes-extended/luci/luci_git.bb
@@ -6,7 +6,7 @@ HOMEPAGE = "https://github.com/openwrt/luci"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=2b42edef8fa55315f34f2370b4715ca9"
 SECTION = "base"
-DEPENDS = "json-c libubox libnl lua5.1 iwinfo openssl libxcrypt"
+DEPENDS = "json-c libubox libnl lua5.1 iwinfo openssl virtual/crypt"
 RDEPENDS_${PN} = "lua5.1"
 
 SRCREV = "07d9006d239b29c9377fccb91b45eb2d0e447919"

--- a/recipes-networking/uhttpd/uhttpd_git.bb
+++ b/recipes-networking/uhttpd/uhttpd_git.bb
@@ -6,7 +6,7 @@ HOMEPAGE = "http://git.openwrt.org/?p=project/uhttpd.git;a=summary"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://main.c;beginline=1;endline=18;md5=ba30601dd30339f7ff3d0ad681d45679"
 SECTION = "base"
-DEPENDS = "libubox ubus json-c ustream-ssl libxcrypt"
+DEPENDS = "libubox ubus json-c ustream-ssl virtual/crypt"
 
 SRC_URI = "\
           git://git.openwrt.org/project/uhttpd.git \

--- a/recipes-networking/umdnsd/umdnsd_git.bb
+++ b/recipes-networking/umdnsd/umdnsd_git.bb
@@ -10,7 +10,7 @@ DEPENDS = "json-c libcap libubox ubus"
 
 SRC_URI = "git://git.openwrt.org/project/mdnsd.git \
           "
-SRCREV = "59e4fc98162d253b4e5ecd110f7bc5ea3962e221"
+SRCREV = "78aa36b0e9808e801c527c6dc47320e593309522"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Fixed error when compile umdnsd with branch **master** 

Tested with: MACHINE **raspberrypi4**

-------------------------------------------------------------
meta-openwrt/recipes-networking/umdnsd/umdnsd_git.bb
**ERROR**
`
|  /ssdext/yocto/poky-gatesgarth/build-openwrt/tmp/work/cortexa7t2hf-neon-vfpv4-poky-linux-musleabi/umdnsd/git-r0/git/util.h:22:19: error: format '%lu' expects argument of type 'long unsigned int', but argument 5 has type 'time_t' {aka 'long long int'} [-Werror=format=]
|    22 |   fprintf(stderr, "mdnsd: %s (%d): " fmt, __func__, __LINE__, ## __VA_ARGS__); \
`

**FIXED:** umdns: fix 64-bit time format string
https://git.openwrt.org/?p=project/mdnsd.git;a=commit;h=78aa36b0e9808e801c527c6dc47320e593309522