### PR TITLE
netifd: Fix build

### DIFF
--- a/recipes-extended/mountd/mountd_git.bb
+++ b/recipes-extended/mountd/mountd_git.bb
@@ -23,7 +23,7 @@ SRCREV_openwrt = "${OPENWRT_SRCREV}"
 S = "${WORKDIR}/git"
 
 do_configure_prepend () {
-    sed -i "s:-Werror --std=gnu99:-Werror -Wno-format-truncation -Wno-format-overflow --std=gnu99:g" ${S}/CMakeLists.txt
+    sed -i "s:-Werror:-Werror -Wno-format-truncation -Wno-format-overflow " ${S}/CMakeLists.txt
 }
 
 do_install_append() {

--- a/recipes-extended/mountd/mountd_git.bb
+++ b/recipes-extended/mountd/mountd_git.bb
@@ -23,7 +23,7 @@ SRCREV_openwrt = "${OPENWRT_SRCREV}"
 S = "${WORKDIR}/git"
 
 do_configure_prepend () {
-    sed -i "s:-Werror:-Werror -Wno-format-truncation -Wno-format-overflow " ${S}/CMakeLists.txt
+    sed -i "s:-Werror:-Werror -Wno-format-truncation -Wno-format-overflow -Wno-unused-result " ${S}/CMakeLists.txt
 }
 
 do_install_append() {


### PR DESCRIPTION
Simplify the sed run to consider only -Werror: this also fixes it
as it cannot find any instances of "-Werror --std=gnu99" (or not all
are found, resulting in a build error).