### PR TITLE
core: make-ext4fs: Fix TARGET_CFLAGS

### DIFF
--- a/recipes-core/make-ext4fs/make-ext4fs_git.bb
+++ b/recipes-core/make-ext4fs/make-ext4fs_git.bb
@@ -17,7 +17,7 @@ S = "${WORKDIR}/git"
 B = "${S}"
 
 CFLAGS += "-I${S}/include -I${S}/libsparse/include"
-TARGET_CFLAGS_append = "-Wno-implicit-function-declaration"
+TARGET_CFLAGS_append = " -Wno-implicit-function-declaration"
 
 TARGET_CC_ARCH += "${LDFLAGS}"
 


### PR DESCRIPTION
Add space to TARGET_CFLAGS_append to fix error:
| aarch64-somainline-linux-gcc: error: unrecognized command line option '-fno-trapping-math-Wno-implicit-function-declaration'; did you mean '--warn-no-implicit-function-declaration'?