### PR TITLE
extended: luci: cmake: Fix missing plural_formula.c in build

### DIFF
--- a/recipes-extended/luci/luci/cmake.patch
+++ b/recipes-extended/luci/luci/cmake.patch
@@ -106,10 +106,10 @@
 +		   COMMAND cd ${PROJECT_SOURCE_DIR}/src && ${CMAKE_BINARY_DIR}/lemon -q T=${PROJECT_SOURCE_DIR}/src/contrib/lempar.c plural_formula.y && cd -
 +		   DEPENDS lemon)
 +add_custom_target(generate_plural_formula ALL
-+		   DEPENDS lemon plural_formula
-+)
++		   DEPENDS lemon plural_formula)
++set_source_files_properties(${PROJECT_SOURCE_DIR}/src/plural_formula.c PROPERTIES GENERATED TRUE)
 +
-+ADD_LIBRARY(parser SHARED src/template_parser.c src/template_utils.c src/template_lmo.c src/template_lualib.c)
++ADD_LIBRARY(parser SHARED src/plural_formula.c src/template_parser.c src/template_utils.c src/template_lmo.c src/template_lualib.c)
 +SET_TARGET_PROPERTIES(parser PROPERTIES PREFIX "")
 +
 +INSTALL(DIRECTORY luasrc/


### PR DESCRIPTION
The autogenerated plural_formula.c file was not included in the
parser.so library: add it to the mix by setting the file as autogenerated
and including it to the shared parser.so library.

This fixes a complain for pluralParseAlloc being an undefined symbol,
since that's where this function is defined (and others as well).

