### PR TITLE
core: rpcd: Fix LuCI authentication issue

### DIFF
--- a/recipes-core/rpcd/rpcd_git.bb
+++ b/recipes-core/rpcd/rpcd_git.bb
@@ -27,6 +27,9 @@ do_install:append() {
     install -Dm 0755 ${OR}/rpcd.config ${D}${sysconfdir}/config/rpcd
     install -Dm 0755 ${OR}/rpcd.init ${D}${sysconfdir}/init.d/rpcd
 
+    mkdir -p ${D}${datadir}/rpcd/acl.d/
+    install -Dm	0644 ${S}/unauthenticated.json ${D}${datadir}/rpcd/acl.d/
+
     mkdir -p ${D}/sbin
     ln -s /usr/sbin/rpcd ${D}/sbin/rpcd
 }


### PR DESCRIPTION
Install the unauthenticated.json file to /usr/share/rpcd/acl.d/
to fix a NetworkError issue at login, preventing unauthenticated
users to... authenticate.