### PR TITLE
fix various build errors: GPL-2.0 license name, compiler flags

### DIFF
--- a/recipes-core/make-ext4fs/make-ext4fs_git.bb
+++ b/recipes-core/make-ext4fs/make-ext4fs_git.bb
@@ -17,7 +17,7 @@ S = "${WORKDIR}/git"
 B = "${S}"
 
 CFLAGS += "-I${S}/include -I${S}/libsparse/include"
-TARGET_CFLAGS_append = "-Wno-implicit-function-declaration"
+TARGET_CFLAGS_append = " -Wno-implicit-function-declaration"
 
 TARGET_CC_ARCH += "${LDFLAGS}"
 

--- a/recipes-core/procd/procd-inittab.bb
+++ b/recipes-core/procd/procd-inittab.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Inittab configuration for procd"
 LICENSE = "GPLv2"
-LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
 
 SRC_URI = "file://inittab \
 	"


### PR DESCRIPTION
`GPL-2.0` license file name in `hardknott` is changed to `GPL-2.0-only`

added a space in compiler flags